### PR TITLE
use latest version of ipycytoscape labextension

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -16,4 +16,4 @@ ${CONDA_DIR}/$VERSION/bin/neo4j-admin set-initial-password neo4jbinder
 export NEO4J_HOME=${CONDA_DIR}/$VERSION
 
 # install jupyter lab extension
-jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-cytoscape@0.2.3
+jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-cytoscape


### PR DESCRIPTION
Removed version number @0.2.3 from ipycytoscape labextension.