### PR TITLE
removed ipycytoscape extension

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -16,4 +16,4 @@ ${CONDA_DIR}/$VERSION/bin/neo4j-admin set-initial-password neo4jbinder
 export NEO4J_HOME=${CONDA_DIR}/$VERSION
 
 # install jupyter lab extension
-jupyter labextension install @jupyter-widgets/jupyterlab-manager jupyter-cytoscape
+jupyter labextension install @jupyter-widgets/jupyterlab-manager 


### PR DESCRIPTION
Removed  ipycytoscape extension, not required for Jupyter Lab 3 and interferes with Pangeo Binder launch.